### PR TITLE
Minor follow ups on PR#5

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ A token bucket rate limiter is defined by four mandatory parameters:
 * `refill_interval`, milliseconds, how often the bucket is refilled with tokens
 * `refill_count`, positive integer, how many tokens are added every refill
 * `delete_when_full`, boolean, whether or not to delete the bucket when it's filled up
-* `override`, none | not_enforced | blocked, whether or not to enforce the rate limit or whether or not all calls should be blocked altogether.
+
+Optional parameters:
+* `override`, `none | not_enforced | blocked`, whether to override the rate limiter to always allow or block requests. `not_enforced` behaves the same as any other regular rate limiter with the exception that once the bucket is empty, one would receive `{ok, rate_limit_not_enforced}` rather than `{error, too_many_requests}`. This features allows a soft-launch of any rate limiter and allows one to tweak the limits before enforcing the rate limiter. `blocked` on the other hand will always return `{error, blocked}` and essentially short circuits that way. This can be useful when you truly don't want to accept any requests any more for this particular rate limiter.
 
 A new speed trap always starts with a full bucket.
 

--- a/src/speed_trap.erl
+++ b/src/speed_trap.erl
@@ -48,7 +48,7 @@
     refill_interval := refill_interval(),
     refill_count := refill_count(),
     delete_when_full := boolean(),
-    override := override()}.
+    override => override()}.
 -type stored_options() ::
   #{bucket_size := bucket_size(),
     refill_interval := refill_interval(),

--- a/src/speed_trap_options.erl
+++ b/src/speed_trap_options.erl
@@ -1,6 +1,6 @@
 -module(speed_trap_options).
 
--export([validate/2, is_blocked/1, is_rate_limit_enforced/1]).
+-export([validate/2]).
 
 -type bad_options() :: {bad_options, [tuple(), ...]}.
 
@@ -31,18 +31,6 @@ validate(Options, AllRequired) when is_map(Options) ->
   end;
 validate(Options, _AllPresent) ->
   {error, {bad_options, [{not_a_map, Options}]}}.
-
--spec is_blocked(speed_trap:options()) -> boolean().
-is_blocked(#{override := blocked}) ->
-  true;
-is_blocked(_) ->
-  false.
-
--spec is_rate_limit_enforced(speed_trap:options()) -> boolean().
-is_rate_limit_enforced(#{override := not_enforced}) ->
-  false;
-is_rate_limit_enforced(_) ->
-  true.
 
 %%-----------------------------------------------------------------------------
 %% Internal functions

--- a/src/speed_trap_token_bucket.erl
+++ b/src/speed_trap_token_bucket.erl
@@ -260,15 +260,12 @@ ctr_to_id(Ctr) ->
 
 do_get_token(#{override := blocked}, _Ctr) ->
   {error, blocked};
-do_get_token(Options, Ctr) ->
+do_get_token(#{override := Override}, Ctr) ->
   case atomics:sub_get(Ctr, 1, 1) of
     N when N >= 0 ->
       {ok, N};
+    _ when Override =:= not_enforced ->
+      {ok, rate_limit_not_enforced};
     _ ->
-      case speed_trap_options:is_rate_limit_enforced(Options) of
-        true ->
-          {error, too_many_requests};
-        false ->
-          {ok, rate_limit_not_enforced}
-      end
+      {error, too_many_requests}
   end.

--- a/test/speed_trap_tests.erl
+++ b/test/speed_trap_tests.erl
@@ -497,16 +497,6 @@ block_non_existing_test() ->
   ?assertEqual({error, no_such_speed_trap}, speed_trap:block(Id)),
   application:stop(speed_trap).
 
-is_blocked_test() ->
-  ?assertEqual(true, speed_trap_options:is_blocked(#{override => blocked})),
-  ?assertEqual(false, speed_trap_options:is_blocked(#{override => not_enforced})),
-  ?assertEqual(false, speed_trap_options:is_blocked(#{override => none})).
-
-is_rate_limit_enforced_test() ->
-  ?assertEqual(false, speed_trap_options:is_rate_limit_enforced(#{override => not_enforced})),
-  ?assertEqual(true, speed_trap_options:is_rate_limit_enforced(#{override => blocked})),
-  ?assertEqual(true, speed_trap_options:is_rate_limit_enforced(#{override => none})).
-
 unique_id(Name) ->
   {Name, unique_resource()}.
 


### PR DESCRIPTION
- Document difference between not_enforced and blocked in override
-  is optional in options
- Do not expose speed_trap_options:is_blocked/1 and speed_trap_options:is_rate_limit_enforced/1 but rather pattern match directly