### PR TITLE
Add support for dynamic rate limiting capability in speed_trap

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,8 @@ speed_trap:delete(Id).
 ```
 
 ## Dynamic rate limiter
-Speed trap includes a dynamic rate limiter that automatically adjusts bucket_size based on rejection rates. This is particularly useful when you need to gradually scale quotas to allow downstream systems time to scale.
+Speed trap includes a dynamic rate limiter that automatically adjusts bucket_size based on rejection rates. 
+This is particularly useful when you need to gradually scale quotas to allow downstream systems time to scale.
 
 ### Features
 - **Automatic upscaling**: When rejection rate exceeds a threshold, bucket_size gradually increases
@@ -143,7 +144,7 @@ A dynamic rate limiter requires the same parameters as a usual one plus the foll
 * `min_bucket_size` - maximum bucket_size (lower limit)
 * `scaling_time_interval` - time window in milliseconds to check for rejections
 * `rejection_rate_threshold` - percentage threshold (0-100) that triggers up/down scaling
-* `bucket_size_adjust_count` - the count to adjust the bucket_size by on each scaling_time_interval
+* `scaling_bucket_size_adjust_count` - the count to adjust the bucket_size by on each scaling_time_interval
 
 ### Example usage
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,62 @@ In order to delete a rate limiter:
 speed_trap:delete(Id).
 ```
 
+## Dynamic rate limiter
+Speed trap includes a dynamic rate limiter that automatically adjusts bucket_size based on rejection rates. This is particularly useful when you need to gradually scale quotas to allow downstream systems time to scale.
+
+### Features
+- **Automatic upscaling**: When rejection rate exceeds a threshold, bucket_size gradually increases
+- **Automatic downscaling**: When rejection rate is below threshold, bucket_size gradually decreases
+- **Configurable bounds**: Set minimum and maximum bucket_size limits
+- **Gradual adjustments**: Prevents sudden spikes by incrementing bucket_size slowly over time
+
+### Configuration
+A dynamic rate limiter requires the same parameters as a usual one plus the following ones:
+
+* `max_bucket_size` - maximum bucket_size (upper limit)
+* `min_bucket_size` - maximum bucket_size (lower limit)
+* `scaling_time_interval` - time window in milliseconds to check for rejections
+* `rejection_rate_threshold` - percentage threshold (0-100) that triggers up/down scaling
+* `bucket_size_adjust_count` - the count to adjust the bucket_size by on each scaling_time_interval
+
+### Example usage
+
+#### Simple approach - let speed_trap calculate defaults:
+```erlang
+application:ensure_all_started(speed_trap).
+Id = {<<"my_dynamodb_table">>, <<"write">>}.
+
+%% Create a dynamic rate limiter with calculated defaults
+DynamicOpts = #{
+  min_bucket_size => 20,                     % Start at 20 units
+  max_bucket_size => 50,                     % Cap at 50 units
+  scaling_time_interval => timer:minutes(5), % Check every 5 minutes
+  scaling_bucket_size_adjust_count => 5      % Adjust by 5 units after each scaling_time_interval
+  rejection_rate_threshold => 30,            % Upscale if >30% rejected
+  refill_interval => timer:seconds(1),       % how often the bucket is refilled
+  refill_count => 20,                        % number of tokens to refill
+  delete_when_full => false                  % Do not delete bucket when full
+  override => none                           % No overrides
+},
+
+speed_trap:new_dynamic(Id, DynamicOpts).        % Create dynamic limiter
+
+%% Use it like a regular speed trap
+speed_trap:try_pass(Id).                        % {ok, RemainingTokens} | {error, too_many_requests}
+
+%% Delete when done
+speed_trap:delete_dynamic(Id).
+```
+
+### How it works
+1. The limiter starts at `min_bucket_size` (e.g., 20 RPS)
+2. Every `scaling_time_interval`, it calculates the rejection rate over that period
+3. If rejection rate > `rejection_rate_threshold`, bucket_size increases by `scaling_bucket_size_adjust_count` (up to `max_bucket_size`)
+4. If rejection rate < `rejection_rate_threshold`, bucket_size decreases by `scaling_bucket_size_adjust_count` (down to `min_bucket_size`)
+5. The underlying token bucket is automatically reconfigured with each adjustment
+
+This gradual scaling gives downstream systems time to scale accordingly.
+
 ## Template rate limiters
 When you do not know upfront all the rate limiters that you need you can add templates for rate limiters and connect them to rate limiter id patterns.
 When a speed trap is not present when calling speed_trap:try_pass/1, speed_trap looks for a pattern

--- a/src/speed_trap_dynamic.erl
+++ b/src/speed_trap_dynamic.erl
@@ -187,9 +187,4 @@ adjust_bucket_size(Id, CurrentBucketSize, NewBucketSize, RefillCount) ->
   %% Ensure minimum refill count
   AdjustedRefillCount = max(1, NewRefillCount),
   ModifyOpts = #{bucket_size => NewBucketSize, refill_count => AdjustedRefillCount},
-  case speed_trap:modify(Id, ModifyOpts) of
-    ok ->
-      ok;
-    {error, _Reason} ->
-      ok % Ignore errors, maybe the bucket doesn't exist yet
-  end.
+  ok = speed_trap:modify(Id, ModifyOpts).

--- a/src/speed_trap_dynamic.erl
+++ b/src/speed_trap_dynamic.erl
@@ -1,0 +1,195 @@
+%%%=============================================================================
+%%% @doc speed_trap_dynamic - Dynamic rate limiter based on rejection rates
+%%%
+%%% This module implements a dynamic rate limiter that automatically adjusts
+%%% bucket_size based on rejection rates. It monitors the rejection rate over a
+%%% configurable time interval and scales bucket_size up or down accordingly.
+%%%
+%%% Key features:
+%%% - Automatic upscaling when rejection rate exceeds threshold
+%%% - Automatic downscaling when rejection rate is below threshold
+%%% - Configurable min/max bucket_size, scaling time intervals, and adjustment increments
+%%% - Gradual bucket_size changes to allow downstream systems to scale
+%%% - Uses atomics for high-performance rejection/acceptance tracking
+%%%
+%%% @copyright 2025 Klarna Bank AB
+%%% @end
+%%%=============================================================================
+-module(speed_trap_dynamic).
+
+-export([start_link/0, register_dynamic_limiter/2, unregister_dynamic_limiter/1, record_rejection/1,
+         record_acceptance/1]).
+
+-behaviour(gen_server).
+
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2]).
+
+-define(SERVER, ?MODULE).
+-define(ETS_DYNAMIC_COUNTERS, speed_trap_dynamic_counters).
+-define(REJECTION_IDX, 1).
+-define(SUCCESS_IDX, 2).
+
+-record(dynamic_state,
+        {id :: speed_trap:id(),
+         counters :: atomics:atomics_ref(),
+         timer_ref :: timer:tref() | undefined}).
+
+-type dynamic_state() :: #dynamic_state{}.
+-type state() :: #{speed_trap:id() => dynamic_state()}.
+
+%%-----------------------------------------------------------------------------
+%% API
+%%-----------------------------------------------------------------------------
+-spec start_link() -> {ok, pid()} | {error, term()}.
+start_link() ->
+  gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+-spec register_dynamic_limiter(speed_trap:id(), speed_trap:options()) ->
+                                ok | {error, already_registered}.
+register_dynamic_limiter(Id, Options) ->
+  gen_server:call(?SERVER, {register, Id, Options}).
+
+-spec unregister_dynamic_limiter(speed_trap:id()) -> ok.
+unregister_dynamic_limiter(Id) ->
+  gen_server:call(?SERVER, {unregister, Id}).
+
+-spec record_rejection(speed_trap:id()) -> ok.
+record_rejection(Id) ->
+  case ets:lookup(?ETS_DYNAMIC_COUNTERS, Id) of
+    [{Id, Counters}] ->
+      atomics:add(Counters, ?REJECTION_IDX, 1);
+    [] ->
+      ok
+  end.
+
+-spec record_acceptance(speed_trap:id()) -> ok.
+record_acceptance(Id) ->
+  case ets:lookup(?ETS_DYNAMIC_COUNTERS, Id) of
+    [{Id, Counters}] ->
+      atomics:add(Counters, ?SUCCESS_IDX, 1);
+    [] ->
+      ok
+  end.
+
+%%-----------------------------------------------------------------------------
+%% gen_server callbacks
+%%-----------------------------------------------------------------------------
+-spec init([]) -> {ok, state()}.
+init([]) ->
+  ?ETS_DYNAMIC_COUNTERS =
+    ets:new(?ETS_DYNAMIC_COUNTERS, [set, protected, named_table, {read_concurrency, true}]),
+  {ok, #{}}.
+
+-spec handle_call(term(), {pid(), term()}, state()) -> {reply, term(), state()}.
+handle_call({register, Id, Options}, _From, State) ->
+  case maps:is_key(Id, State) of
+    true ->
+      {reply, {error, already_registered}, State};
+    false ->
+      #{scaling_time_interval := TimeInterval} = Options,
+      % Create atomic counters for rejections and acceptances
+      Counters = atomics:new(2, [{signed, false}]),
+      atomics:put(Counters, ?REJECTION_IDX, 0),
+      atomics:put(Counters, ?SUCCESS_IDX, 0),
+      {ok, TimerRef} = timer:send_after(TimeInterval, self(), {check_and_adjust, Id}),
+      DynState =
+        #dynamic_state{id = Id,
+                       counters = Counters,
+                       timer_ref = TimerRef},
+      NewState = State#{Id => DynState},
+      ets:insert(?ETS_DYNAMIC_COUNTERS, {Id, Counters}),
+      {reply, ok, NewState}
+  end;
+handle_call({unregister, Id}, _From, State) ->
+  case maps:take(Id, State) of
+    {DynState, NewState} ->
+      case DynState#dynamic_state.timer_ref of
+        undefined ->
+          ok;
+        TimerRef ->
+          timer:cancel(TimerRef)
+      end,
+      ets:delete(?ETS_DYNAMIC_COUNTERS, Id),
+      {reply, ok, NewState};
+    error ->
+      {reply, ok, State}
+  end;
+handle_call(_Request, _From, State) ->
+  {reply, {error, unknown_call}, State}.
+
+-spec handle_cast(term(), state()) -> {noreply, state()}.
+handle_cast(_Request, State) ->
+  {noreply, State}.
+
+-spec handle_info(term(), state()) -> {noreply, state()}.
+handle_info({check_and_adjust, Id}, State) ->
+  case maps:get(Id, State, undefined) of
+    undefined ->
+      {noreply, State};
+    DynState ->
+      NewDynState = check_and_adjust_bucket_size(DynState),
+      NewState = State#{Id => NewDynState},
+      {noreply, NewState}
+  end;
+handle_info(_Info, State) ->
+  {noreply, State}.
+
+%%-----------------------------------------------------------------------------
+%% Internal functions
+%%-----------------------------------------------------------------------------
+-spec check_and_adjust_bucket_size(dynamic_state()) -> dynamic_state().
+check_and_adjust_bucket_size(DynState) ->
+  #dynamic_state{id = Id, counters = Counters} = DynState,
+  {ok,
+   #{bucket_size := CurrentBucketSize,
+     min_bucket_size := MinBucketSize,
+     max_bucket_size := MaxBucketSize,
+     refill_count := RefillCount,
+     scaling_time_interval := TimeInterval,
+     rejection_rate_threshold := Threshold,
+     scaling_bucket_size_adjust_count := AdjustCount}} =
+    speed_trap_token_bucket:options(Id),
+  % Read and reset counters atomically
+  TotalRejections = atomics:exchange(Counters, ?REJECTION_IDX, 0),
+  TotalSuccesses = atomics:exchange(Counters, ?SUCCESS_IDX, 0),
+  TotalRequests = TotalRejections + TotalSuccesses,
+  RejectionRate =
+    case TotalRequests of
+      0 ->
+        0;
+      _ ->
+        round(TotalRejections / TotalRequests * 100)
+    end,
+  if RejectionRate > Threshold andalso CurrentBucketSize < MaxBucketSize ->
+       % Upscale: increase bucket_size
+       NewQ = min(CurrentBucketSize + AdjustCount, MaxBucketSize),
+       adjust_bucket_size(Id, CurrentBucketSize, NewQ, RefillCount),
+       NewQ;
+     RejectionRate < Threshold andalso CurrentBucketSize > MinBucketSize ->
+       % Downscale: decrease bucket_size
+       NewQ = max(CurrentBucketSize - AdjustCount, MinBucketSize),
+       adjust_bucket_size(Id, CurrentBucketSize, NewQ, RefillCount),
+       NewQ;
+     true ->
+       % No adjustment needed
+       CurrentBucketSize
+  end,
+  % Schedule next check
+  {ok, TimerRef} = timer:send_after(TimeInterval, self(), {check_and_adjust, Id}),
+  DynState#dynamic_state{timer_ref = TimerRef}.
+
+-spec adjust_bucket_size(speed_trap:id(), pos_integer(), pos_integer(), pos_integer()) -> ok.
+adjust_bucket_size(Id, CurrentBucketSize, NewBucketSize, RefillCount) ->
+  %% Calculate scaling factor
+  ScalingFactor = NewBucketSize / CurrentBucketSize,
+  %% Scale refill_count proportionally
+  NewRefillCount = round(RefillCount * ScalingFactor),
+  %% Ensure minimum refill count
+  AdjustedRefillCount = max(1, NewRefillCount),
+  ModifyOpts = #{bucket_size => NewBucketSize, refill_count => AdjustedRefillCount},
+  case speed_trap:modify(Id, ModifyOpts) of
+    ok ->
+      ok;
+    {error, _Reason} ->
+      ok % Ignore errors, maybe the bucket doesn't exist yet
+  end.

--- a/src/speed_trap_options.erl
+++ b/src/speed_trap_options.erl
@@ -13,8 +13,7 @@ validate(Options, AllRequired) when is_map(Options) ->
       false ->
         [];
       true ->
-        [{max_bucket_size, true, fun validate_bucket_size/1},
-         {min_bucket_size, true, fun validate_bucket_size/1},
+        [{max_bucket_size, true, fun validate_limit_bucket_size/2},
          {scaling_time_interval, true, fun validate_scaling_time_interval/1},
          {rejection_rate_threshold, true, fun validate_rejection_rate_threshold/1},
          {scaling_bucket_size_adjust_count, true, fun validate_scaling_bucket_size_adjust_count/1}]
@@ -56,7 +55,12 @@ validate_key(Key, Options, ValidationFn, Mandatory, Required) ->
     false when not Mandatory orelse not Required ->
       ok;
     true ->
-      ValidationFn(maps:get(Key, Options))
+      case erlang:fun_info(ValidationFn, arity) of
+        {arity, 1} ->
+          ValidationFn(maps:get(Key, Options));
+        {arity, 2} ->
+          ValidationFn(maps:get(Key, Options), Options)
+      end
   end.
 
 -spec validate_bucket_size(term()) -> ok | {error, {bucket_size, term()}}.
@@ -64,6 +68,18 @@ validate_bucket_size(BucketSize) when is_integer(BucketSize), BucketSize >= 0 ->
   ok;
 validate_bucket_size(BucketSize) ->
   {error, {bucket_size, BucketSize}}.
+
+validate_limit_bucket_size(MaxBucketSize, Options) ->
+  MinBucketSize = maps:get(min_bucket_size, Options),
+  AreNumbers = is_integer(MinBucketSize) andalso is_integer(MaxBucketSize),
+  WithinBoundaries =
+    MinBucketSize < MaxBucketSize andalso MinBucketSize >= 0 andalso MaxBucketSize >= 0,
+  case AreNumbers andalso WithinBoundaries of
+    true ->
+      ok;
+    false ->
+      {error, {limit_bucket_size, {MinBucketSize, MaxBucketSize}}}
+  end.
 
 -spec validate_refill_interval(term()) -> ok | {error, {refill_interval, term()}}.
 validate_refill_interval(RefillInterval) when is_integer(RefillInterval), RefillInterval > 0 ->
@@ -99,7 +115,7 @@ validate_scaling_time_interval(TimeInterval) ->
   {error, {invalid_time_interval, TimeInterval}}.
 
 validate_rejection_rate_threshold(Threshold)
-  when is_number(Threshold), Threshold >= 0, Threshold =< 100 ->
+  when is_number(Threshold), Threshold > 0, Threshold =< 100 ->
   ok;
 validate_rejection_rate_threshold(Threshold) ->
   {error, {invalid_threshold, Threshold}}.

--- a/src/speed_trap_sup.erl
+++ b/src/speed_trap_sup.erl
@@ -34,7 +34,7 @@ init([]) ->
     #{strategy => one_for_all,
       intensity => 0,
       period => 1},
-  ChildSpecs = [child(speed_trap_token_bucket)],
+  ChildSpecs = [child(speed_trap_token_bucket), child(speed_trap_dynamic)],
   {ok, {SupFlags, ChildSpecs}}.
 
 %%-----------------------------------------------------------------------------

--- a/test/speed_trap_tests.erl
+++ b/test/speed_trap_tests.erl
@@ -622,6 +622,321 @@ template_based_overrides_test() ->
   application:unset_env(speed_trap, id_patterns),
   application:unset_env(speed_trap, templates).
 
+dynamic_rate_limiter_bad_options_test() ->
+  application:ensure_all_started(speed_trap),
+  Id = unique_id(?FUNCTION_NAME),
+  %% Invalid: negative threshold
+  BadOpts1 =
+    #{min_bucket_size => 20,
+      max_bucket_size => 50,
+      scaling_time_interval => timer:seconds(1),
+      rejection_rate_threshold => -10,
+      scaling_bucket_size_adjust_count => 5,
+      refill_interval => 1000,
+      refill_count => 1,
+      delete_when_full => false},
+  ?assertMatch({error, {bad_options, _}}, speed_trap:new_dynamic(Id, BadOpts1)),
+  %% Invalid: threshold > 100
+  BadOpts2 =
+    #{min_bucket_size => 20,
+      max_bucket_size => 50,
+      scaling_time_interval => timer:seconds(1),
+      rejection_rate_threshold => 150,
+      scaling_bucket_size_adjust_count => 5,
+      refill_interval => 1000,
+      refill_count => 1,
+      delete_when_full => false},
+  ?assertMatch({error, {bad_options, _}}, speed_trap:new_dynamic(Id, BadOpts2)),
+  application:stop(speed_trap).
+
+dynamic_rate_limiter_delete_test() ->
+  application:ensure_all_started(speed_trap),
+  Id = unique_id(?FUNCTION_NAME),
+  DynamicOpts =
+    #{min_bucket_size => 20,
+      max_bucket_size => 50,
+      scaling_time_interval => timer:seconds(1),
+      rejection_rate_threshold => 30,
+      scaling_bucket_size_adjust_count => 5,
+      refill_interval => 1000,
+      refill_count => 1,
+      delete_when_full => false},
+  ok = speed_trap:new_dynamic(Id, DynamicOpts),
+  ok = speed_trap:delete_dynamic(Id),
+  ?assertEqual({error, no_such_speed_trap}, speed_trap:try_pass(Id)),
+  application:stop(speed_trap).
+
+dynamic_rate_limiter_basic_test() ->
+  application:ensure_all_started(speed_trap),
+  Id = unique_id(?FUNCTION_NAME),
+  DynamicOpts =
+    #{min_bucket_size => 20,
+      max_bucket_size => 50,
+      scaling_time_interval => timer:seconds(10),
+      rejection_rate_threshold => 30,
+      scaling_bucket_size_adjust_count => 5,
+      refill_interval => 1000,
+      refill_count => 1,
+      delete_when_full => false},
+  ok = speed_trap:new_dynamic(Id, DynamicOpts),
+  %% Initially starts at min_bucket_size (20)
+  ?assertMatch({ok, _}, speed_trap:try_pass(Id)),
+  ok = speed_trap:delete_dynamic(Id),
+  application:stop(speed_trap).
+
+%% Test dynamic rate limiter upscaling when rejection rate exceeds threshold
+dynamic_rate_limiter_upscaling_detailed_test() ->
+  application:ensure_all_started(speed_trap),
+  Id = unique_id(?FUNCTION_NAME),
+  InitialBucketSize = 10,
+  ScalingAdjustCount = 5,
+  DynamicOpts =
+    #{min_bucket_size => InitialBucketSize,
+      max_bucket_size => 30,
+      scaling_time_interval => 200,
+      rejection_rate_threshold => 50,
+      scaling_bucket_size_adjust_count => ScalingAdjustCount,
+      refill_interval => 1000,
+      refill_count => 1,
+      delete_when_full => false},
+  ok = speed_trap:new_dynamic(Id, DynamicOpts),
+  %% Get initial bucket size
+  {ok, InitialOpts} = speed_trap:options(Id),
+  ?assertEqual(InitialBucketSize, maps:get(bucket_size, InitialOpts)),
+  %% Generate high rejection rate by exhausting bucket multiple times
+  %% This should trigger upscaling
+  [speed_trap:try_pass(Id) || _ <- lists:seq(1, 50)],
+  %% Wait for scaling interval plus margin
+  timer:sleep(300),
+  %% Check that bucket size has increased
+  {ok, FinalOpts} = speed_trap:options(Id),
+  FinalBucketSize = maps:get(bucket_size, FinalOpts),
+  ?assert(FinalBucketSize > InitialBucketSize),
+  ?assertEqual(InitialBucketSize + ScalingAdjustCount, FinalBucketSize),
+  ok = speed_trap:delete_dynamic(Id),
+  application:stop(speed_trap).
+
+%% Test dynamic rate limiter downscaling when rejection rate is below threshold
+dynamic_rate_limiter_downscaling_test() ->
+  application:ensure_all_started(speed_trap),
+  Id = unique_id(?FUNCTION_NAME),
+  ScalingAdjustCount = 3,
+  DynamicOpts =
+    #{min_bucket_size => 5,
+      max_bucket_size => 20,
+      scaling_time_interval => 200,
+      rejection_rate_threshold => 50,
+      scaling_bucket_size_adjust_count => ScalingAdjustCount,
+      refill_interval => 100,
+      refill_count => 1,
+      delete_when_full => false},
+  ok = speed_trap:new_dynamic(Id, DynamicOpts),
+  %% Manually increase bucket size to simulate previous upscaling
+  UpScaledBucketSize = 15,
+  ok = speed_trap:modify(Id, #{bucket_size => UpScaledBucketSize}),
+  {ok, InitialOpts} = speed_trap:options(Id),
+  ?assertEqual(UpScaledBucketSize, maps:get(bucket_size, InitialOpts)),
+  %% Generate low rejection rate by making successful requests
+  %% Make requests that are well within the bucket capacity
+  [speed_trap:try_pass(Id) || _ <- lists:seq(1, 3)],
+  %% Wait for scaling interval plus margin
+  timer:sleep(300),
+  %% Check that bucket size has decreased
+  {ok, FinalOpts} = speed_trap:options(Id),
+  FinalBucketSize = maps:get(bucket_size, FinalOpts),
+  ?assert(FinalBucketSize < UpScaledBucketSize),
+  ?assertEqual(UpScaledBucketSize - ScalingAdjustCount, FinalBucketSize),
+  ok = speed_trap:delete_dynamic(Id),
+  application:stop(speed_trap).
+
+%% Test that bucket size never goes below minimum
+dynamic_rate_limiter_minimum_bounds_test() ->
+  application:ensure_all_started(speed_trap),
+  Id = unique_id(?FUNCTION_NAME),
+  MinBucketSize = 10,
+  DynamicOpts =
+    #{min_bucket_size => MinBucketSize,
+      max_bucket_size => 20,
+      scaling_time_interval => 200,
+      rejection_rate_threshold => 50,
+      scaling_bucket_size_adjust_count => 10, %% Large adjustment to test bounds
+      refill_interval => 1000,
+      refill_count => 1,
+      delete_when_full => false},
+  ok = speed_trap:new_dynamic(Id, DynamicOpts),
+  %% Generate very low rejection rate to trigger downscaling
+  lists:foreach(fun(_) ->
+                   %% Make only successful requests
+                   [speed_trap:try_pass(Id) || _ <- lists:seq(1, 2)],
+                   timer:sleep(50)
+                end,
+                lists:seq(1, 10)),
+  %% Wait for multiple scaling intervals
+  timer:sleep(500),
+  %% Check that bucket size never went below minimum
+  {ok, FinalOpts} = speed_trap:options(Id),
+  FinalBucketSize = maps:get(bucket_size, FinalOpts),
+  ?assertEqual(FinalBucketSize, MinBucketSize),
+  ok = speed_trap:delete_dynamic(Id),
+  application:stop(speed_trap).
+
+%% Test that bucket size never exceeds maximum
+dynamic_rate_limiter_maximum_bounds_test() ->
+  application:ensure_all_started(speed_trap),
+  Id = unique_id(?FUNCTION_NAME),
+  MaxBucketSize = 15,
+  DynamicOpts =
+    #{min_bucket_size => 5,
+      max_bucket_size => MaxBucketSize,
+      scaling_time_interval => 200,
+      rejection_rate_threshold => 50,
+      scaling_bucket_size_adjust_count => 10, %% Large adjustment to test bounds
+      refill_interval => 1000,
+      refill_count => 1,
+      delete_when_full => false},
+  ok = speed_trap:new_dynamic(Id, DynamicOpts),
+  %% Generate very high rejection rate to trigger upscaling
+  lists:foreach(fun(_) ->
+                   %% Exhaust bucket multiple times to generate high rejection rate
+                   [speed_trap:try_pass(Id) || _ <- lists:seq(1, 20)]
+                end,
+                lists:seq(1, 10)),
+  %% Wait for scaling interval
+  timer:sleep(300),
+  %% Check that bucket size never exceeded maximum
+  {ok, FinalOpts} = speed_trap:options(Id),
+  FinalBucketSize = maps:get(bucket_size, FinalOpts),
+  ?assertEqual(FinalBucketSize, MaxBucketSize),
+  ok = speed_trap:delete_dynamic(Id),
+  application:stop(speed_trap).
+
+%% Test dynamic rate limiter with no requests (should not change bucket size)
+dynamic_rate_limiter_no_requests_test() ->
+  application:ensure_all_started(speed_trap),
+  Id = unique_id(?FUNCTION_NAME),
+  InitialBucketSize = 10,
+  DynamicOpts =
+    #{min_bucket_size => InitialBucketSize,
+      max_bucket_size => 20,
+      scaling_time_interval => 200,
+      rejection_rate_threshold => 50,
+      scaling_bucket_size_adjust_count => 5,
+      refill_interval => 1000,
+      refill_count => 1,
+      delete_when_full => false},
+  ok = speed_trap:new_dynamic(Id, DynamicOpts),
+  %% Don't make any requests, just wait
+  timer:sleep(300),
+  %% Check that bucket size hasn't changed
+  {ok, FinalOpts} = speed_trap:options(Id),
+  FinalBucketSize = maps:get(bucket_size, FinalOpts),
+  ?assertEqual(InitialBucketSize, FinalBucketSize),
+  ok = speed_trap:delete_dynamic(Id),
+  application:stop(speed_trap).
+
+%% Test dynamic rate limiter with all successes (should downscale)
+dynamic_rate_limiter_all_successes_test() ->
+  application:ensure_all_started(speed_trap),
+  Id = unique_id(?FUNCTION_NAME),
+  ScalingCount = 3,
+  DynamicOpts =
+    #{min_bucket_size => 5,
+      max_bucket_size => 15,
+      scaling_time_interval => 200,
+      rejection_rate_threshold => 50,
+      scaling_bucket_size_adjust_count => ScalingCount,
+      refill_interval => 1000,
+      refill_count => 1,
+      delete_when_full => false},
+  ok = speed_trap:new_dynamic(Id, DynamicOpts),
+  %% Manually increase bucket size first
+  ok = speed_trap:modify(Id, #{bucket_size => 12}),
+  {ok, InitialOpts} = speed_trap:options(Id),
+  InitialBucketSize = maps:get(bucket_size, InitialOpts),
+  ?assertEqual(12, InitialBucketSize),
+  %% Generate 0% rejection rate by making only successful requests
+  lists:foreach(fun(_) ->
+                   %% Make only a few requests that will all succeed
+                   speed_trap:try_pass(Id),
+                   timer:sleep(50)
+                end,
+                lists:seq(1, 8)),
+  %% Wait for scaling interval
+  timer:sleep(300),
+  %% Check that bucket size has decreased
+  {ok, FinalOpts} = speed_trap:options(Id),
+  FinalBucketSize = maps:get(bucket_size, FinalOpts),
+  %% After (8 * 50 + 300)/200 = at least 3 downscaling intervals have happened => 12 - (3 * 3) = 3
+  %% However, we never drop below 5.
+  ?assertEqual(FinalBucketSize, 5),
+  ok = speed_trap:delete_dynamic(Id),
+  application:stop(speed_trap).
+
+%% Test dynamic rate limiter adjustment timing
+dynamic_rate_limiter_timing_test() ->
+  application:ensure_all_started(speed_trap),
+  Id = unique_id(?FUNCTION_NAME),
+  ScalingInterval = 300,
+  DynamicOpts =
+    #{min_bucket_size => 5,
+      max_bucket_size => 15,
+      scaling_time_interval => ScalingInterval,
+      rejection_rate_threshold => 50,
+      scaling_bucket_size_adjust_count => 3,
+      refill_interval => 1000,
+      refill_count => 1,
+      delete_when_full => false},
+  ok = speed_trap:new_dynamic(Id, DynamicOpts),
+  StartTime = erlang:monotonic_time(millisecond),
+  %% Generate high rejection rate
+  [speed_trap:try_pass(Id) || _ <- lists:seq(1, 20)],
+  %% Check that no adjustment happened before the scaling interval
+  timer:sleep(ScalingInterval - 100),
+  {ok, MidOpts} = speed_trap:options(Id),
+  MidBucketSize = maps:get(bucket_size, MidOpts),
+  ?assertEqual(5, MidBucketSize),
+  %% Wait for the full scaling interval
+  timer:sleep(200),
+  %% Check that adjustment happened after the scaling interval
+  {ok, FinalOpts} = speed_trap:options(Id),
+  FinalBucketSize = maps:get(bucket_size, FinalOpts),
+  ?assert(FinalBucketSize > 5),
+  EndTime = erlang:monotonic_time(millisecond),
+  ElapsedTime = EndTime - StartTime,
+  ?assert(ElapsedTime >= ScalingInterval),
+  ok = speed_trap:delete_dynamic(Id),
+  application:stop(speed_trap).
+
+%% Test dynamic rate limiter with gradual scaling
+dynamic_rate_limiter_gradual_scaling_test() ->
+  application:ensure_all_started(speed_trap),
+  Id = unique_id(?FUNCTION_NAME),
+  DynamicOpts =
+    #{min_bucket_size => 5,
+      max_bucket_size => 20,
+      scaling_time_interval => 200,
+      rejection_rate_threshold => 50,
+      scaling_bucket_size_adjust_count => 2, %% Small adjustments
+      refill_interval => 1000,
+      refill_count => 1,
+      delete_when_full => false},
+  ok = speed_trap:new_dynamic(Id, DynamicOpts),
+  %% Generate moderate rejection rate over multiple intervals
+  lists:foreach(fun(Round) ->
+                   %% Generate some rejections
+                   [speed_trap:try_pass(Id) || _ <- lists:seq(1, 30)],
+                   %% Wait for scaling interval
+                   timer:sleep(210),
+                   %% Check bucket size after each round
+                   {ok, Opts} = speed_trap:options(Id),
+                   BucketSize = maps:get(bucket_size, Opts),
+                   ExpectedMinSize = 5 + Round * 2,
+                   ?assert(BucketSize >= ExpectedMinSize)
+                end,
+                lists:seq(1, 3)),
+  ok = speed_trap:delete_dynamic(Id),
+  application:stop(speed_trap).
+
 unique_id(Name) ->
   {Name, unique_resource()}.
 
@@ -635,4 +950,5 @@ unique_resource() ->
   Int = erlang:unique_integer([positive]),
   <<"resource", (integer_to_binary(Int))/binary>>.
 
+%%
 -endif.

--- a/test/speed_trap_tests.erl
+++ b/test/speed_trap_tests.erl
@@ -647,6 +647,18 @@ dynamic_rate_limiter_bad_options_test() ->
       refill_count => 1,
       delete_when_full => false},
   ?assertMatch({error, {bad_options, _}}, speed_trap:new_dynamic(Id, BadOpts2)),
+  %% Invalid: min_bucket_size > max_bucket_size
+  BadOpts3 =
+    #{min_bucket_size => 120,
+      max_bucket_size => 50,
+      scaling_time_interval => timer:seconds(1),
+      rejection_rate_threshold => 50,
+      scaling_bucket_size_adjust_count => 5,
+      refill_interval => 1000,
+      refill_count => 1,
+      delete_when_full => false},
+  ?assertMatch({error, {bad_options, [{limit_bucket_size, {_, _}}]}},
+               speed_trap:new_dynamic(Id, BadOpts3)),
   application:stop(speed_trap).
 
 dynamic_rate_limiter_delete_test() ->


### PR DESCRIPTION
Currently, our rate limiters are quite static: if you call us for more than X RPS we will reject you.
The reality is a bit more complex if you happen to use other services that require some warmup time before scaling (i.e: DynamoDB tables with autoscaling feature that needs 5-10 mins to kick in).

Hence, we need a rate_limiter that starts with a low quota in the beginning and then progressively increases them up to a max limit. This way, we can be more accommodating for our clients calling us while protecting ourselves from being overloaded while our infra/downstream services are not yet fully warmed up.

This PR adds support for creating dynamic rate_limiters that can upscale and downscale based on the rejection_rate_threshold during the scaling_time_interval.

I went for creating another module for handling all the logic around rejection/acceptance stats while still using the token_bucket for tracking the regular quotas.

