### PR TITLE
Dynamic_rate limiter should not downscale once it is operating at a stable upscaled capacity

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,11 +178,24 @@ speed_trap:delete_dynamic(Id).
 ### How it works
 1. The limiter starts at `min_bucket_size` (e.g., 20 RPS)
 2. Every `scaling_time_interval`, it calculates the rejection rate over that period
-3. If rejection rate > `rejection_rate_threshold`, bucket_size increases by `scaling_bucket_size_adjust_count` (up to `max_bucket_size`)
-4. If rejection rate < `rejection_rate_threshold`, bucket_size decreases by `scaling_bucket_size_adjust_count` (down to `min_bucket_size`)
-5. The underlying token bucket is automatically reconfigured with each adjustment
+3. If rejection rate > `rejection_rate_threshold`, bucket_size increases by increments of `scaling_bucket_size_adjust_count` (up to `max_bucket_size`)
+4. If rejection rate < `rejection_rate_threshold` **AND** total requests < `bucket_size - scaling_bucket_size_adjust_count`, bucket_size decreases by decrements of `scaling_bucket_size_adjust_count` (down to `min_bucket_size`)
+5. If rejection rate < `rejection_rate_threshold` but traffic is high enough (>= `bucket_size - scaling_bucket_size_adjust_count`), bucket_size remains stable
+6. The underlying token bucket is automatically reconfigured with each adjustment
 
 This gradual scaling gives downstream systems time to scale accordingly.
+
+### Stability at capacity
+The dynamic rate limiter is designed to remain stable when operating at capacity with no/few rejections. 
+If the system has scaled up to handle traffic and is now running smoothly, 
+it won't immediately downscale just because there are no rejections. Instead, it only downscales 
+when traffic actually drops below the threshold (`bucket_size - scaling_bucket_size_adjust_count`).
+
+This prevents oscillation where the limiter would:
+1. Upscale due to rejections
+2. Immediately downscale because rejection rate drops to 0%
+3. Upscale again due to new rejections
+4. Repeat...
 
 ## Template rate limiters
 When you do not know upfront all the rate limiters that you need you can add templates for rate limiters and connect them to rate limiter id patterns.

--- a/src/speed_trap_dynamic.erl
+++ b/src/speed_trap_dynamic.erl
@@ -160,18 +160,27 @@ check_and_adjust_bucket_size(DynState) ->
       _ ->
         round(TotalRejections / TotalRequests * 100)
     end,
+  %% Calculate the target bucket size after potential downscaling
+  DownscaleTarget = CurrentBucketSize - AdjustCount,
+  %% Only downscale if rejection rate is below threshold AND total requests
+  %% are less than the downscale target. This prevents downscaling when we're
+  %% at capacity with no rejections (i.e., traffic is utilizing the current limit).
+  ShouldDownscale =
+    RejectionRate < Threshold
+    andalso CurrentBucketSize > MinBucketSize
+    andalso TotalRequests < DownscaleTarget,
   if RejectionRate > Threshold andalso CurrentBucketSize < MaxBucketSize ->
        % Upscale: increase bucket_size
        NewQ = min(CurrentBucketSize + AdjustCount, MaxBucketSize),
        adjust_bucket_size(Id, CurrentBucketSize, NewQ, RefillCount),
        NewQ;
-     RejectionRate < Threshold andalso CurrentBucketSize > MinBucketSize ->
-       % Downscale: decrease bucket_size
-       NewQ = max(CurrentBucketSize - AdjustCount, MinBucketSize),
+     ShouldDownscale ->
+       % Downscale: decrease bucket_size only when traffic is low enough
+       NewQ = max(DownscaleTarget, MinBucketSize),
        adjust_bucket_size(Id, CurrentBucketSize, NewQ, RefillCount),
        NewQ;
      true ->
-       % No adjustment needed
+       % No adjustment needed - either at optimal size or traffic justifies current size
        CurrentBucketSize
   end,
   % Schedule next check

--- a/test/speed_trap_tests.erl
+++ b/test/speed_trap_tests.erl
@@ -949,6 +949,101 @@ dynamic_rate_limiter_gradual_scaling_test() ->
   ok = speed_trap:delete_dynamic(Id),
   application:stop(speed_trap).
 
+%% Test that dynamic rate limiter stays stable at an intermediate bucket size
+%% when traffic is high enough (>= bucket_size - adjust_count), even with 0% rejection rate.
+%% This prevents unnecessary downscaling when the system is operating at capacity.
+dynamic_rate_limiter_stable_at_intermediate_size_test() ->
+  application:ensure_all_started(speed_trap),
+  Id = unique_id(?FUNCTION_NAME),
+  MinBucketSize = 15,
+  MaxBucketSize = 30,
+  AdjustCount = 5,
+  ScalingInterval = 500,
+  DynamicOpts =
+    #{min_bucket_size => MinBucketSize,
+      max_bucket_size => MaxBucketSize,
+      scaling_time_interval => ScalingInterval,
+      rejection_rate_threshold => 30,
+      scaling_bucket_size_adjust_count => AdjustCount,
+      refill_interval => 1000,
+      refill_count => 1,
+      delete_when_full => false},
+  ok = speed_trap:new_dynamic(Id, DynamicOpts),
+  %% Verify we start at min_bucket_size
+  {ok, InitialOpts} = speed_trap:options(Id),
+  ?assertEqual(MinBucketSize, maps:get(bucket_size, InitialOpts)),
+  %% Generate high rejection rate to trigger upscaling from 15 to 20
+  %% Make many requests quickly to exhaust the bucket and cause rejections
+  [speed_trap:try_pass(Id) || _ <- lists:seq(1, 100)],
+  %% Wait for scaling interval plus margin
+  timer:sleep(ScalingInterval + 100),
+  %% Verify bucket size has increased to 20
+  {ok, UpscaledOpts} = speed_trap:options(Id),
+  UpscaledBucketSize = maps:get(bucket_size, UpscaledOpts),
+  ?assertEqual(MinBucketSize + AdjustCount, UpscaledBucketSize),
+  %% Modify to refill bucket to full capacity before stability test
+  %% This ensures we start with a full bucket of 20 tokens
+  ok = speed_trap:modify(Id, #{bucket_size => UpscaledBucketSize}),
+  %% Now generate traffic that is high enough to justify the current bucket size (20)
+  %% but with 0% rejection rate.
+  [speed_trap:try_pass(Id) || _ <- lists:seq(1, 20)],
+  %% Wait for the full scaling interval plus margin
+  timer:sleep(ScalingInterval + 100),
+  %% Verify bucket size has NOT decreased
+  {ok, Opts} = speed_trap:options(Id),
+  CurrentBucketSize = maps:get(bucket_size, Opts),
+  ?assertEqual(UpscaledBucketSize,
+               CurrentBucketSize,
+               "Bucket size should remain stable when traffic justifies it"),
+  ok = speed_trap:delete_dynamic(Id),
+  application:stop(speed_trap).
+
+%% Test that dynamic rate limiter correctly downscales when traffic drops
+%% below (bucket_size - adjust_count) threshold
+dynamic_rate_limiter_downscales_on_low_traffic_test() ->
+  application:ensure_all_started(speed_trap),
+  Id = unique_id(?FUNCTION_NAME),
+  MinBucketSize = 15,
+  MaxBucketSize = 30,
+  AdjustCount = 5,
+  ScalingInterval = 500,
+  DynamicOpts =
+    #{min_bucket_size => MinBucketSize,
+      max_bucket_size => MaxBucketSize,
+      scaling_time_interval => ScalingInterval,
+      rejection_rate_threshold => 30,
+      scaling_bucket_size_adjust_count => AdjustCount,
+      refill_interval => 1000,
+      refill_count => 1,
+      delete_when_full => false},
+  ok = speed_trap:new_dynamic(Id, DynamicOpts),
+  %% Verify we start at min_bucket_size
+  {ok, InitialOpts} = speed_trap:options(Id),
+  ?assertEqual(MinBucketSize, maps:get(bucket_size, InitialOpts)),
+  %% Generate high rejection rate to trigger upscaling from 15 to 20
+  [speed_trap:try_pass(Id) || _ <- lists:seq(1, 100)],
+  %% Wait for scaling interval plus margin
+  timer:sleep(ScalingInterval + 100),
+  %% Verify bucket size has increased to 20
+  {ok, UpscaledOpts} = speed_trap:options(Id),
+  UpscaledBucketSize = maps:get(bucket_size, UpscaledOpts),
+  ?assertEqual(MinBucketSize + AdjustCount, UpscaledBucketSize),
+  %% Now generate low traffic that doesn't justify the current bucket size (20)
+  %% TotalRequests < bucket_size - adjust_count (20 - 5 = 15)
+  %% We'll make only 10 requests
+  [speed_trap:try_pass(Id) || _ <- lists:seq(1, 10)],
+  %% Wait for scaling interval plus margin
+  timer:sleep(ScalingInterval + 100),
+  %% Verify bucket size has decreased back to 15
+  {ok, FinalOpts} = speed_trap:options(Id),
+  FinalBucketSize = maps:get(bucket_size, FinalOpts),
+  ExpectedBucketSize = UpscaledBucketSize - AdjustCount,
+  ?assertEqual(ExpectedBucketSize,
+               FinalBucketSize,
+               "Bucket size should decrease when traffic is low"),
+  ok = speed_trap:delete_dynamic(Id),
+  application:stop(speed_trap).
+
 unique_id(Name) ->
   {Name, unique_resource()}.
 


### PR DESCRIPTION
Only downscale if rejection rate is below threshold AND total requests are less than the downscale target. 
This prevents downscaling when we're at capacity with no/few rejections (i.e., traffic is utilizing the current limit).