### PR TITLE
Downscale dynamic_rate_limiter only when the total_requests <downscaled_capacity during a scaling interval, remove redundant tests and simplify some of the exisiting tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,9 +179,16 @@ speed_trap:delete_dynamic(Id).
 1. The limiter starts at `min_bucket_size` (e.g., 20 RPS)
 2. Every `scaling_time_interval`, it calculates the rejection rate over that period
 3. If rejection rate > `rejection_rate_threshold`, bucket_size increases by increments of `scaling_bucket_size_adjust_count` (up to `max_bucket_size`)
-4. If rejection rate < `rejection_rate_threshold` **AND** total requests < `bucket_size - scaling_bucket_size_adjust_count`, bucket_size decreases by decrements of `scaling_bucket_size_adjust_count` (down to `min_bucket_size`)
-5. If rejection rate < `rejection_rate_threshold` but traffic is high enough (>= `bucket_size - scaling_bucket_size_adjust_count`), bucket_size remains stable
+4. If rejection rate < `rejection_rate_threshold` **AND** total requests < downscaled capacity during the scaling_interval then bucket_size decreases by decrements of `scaling_bucket_size_adjust_count` (down to `min_bucket_size`)
+5. If rejection rate < `rejection_rate_threshold` but traffic is high enough (>= downscaled capacity), bucket_size remains stable
 6. The underlying token bucket is automatically reconfigured with each adjustment
+
+The **downscaled capacity** is calculated as the throughput the bucket would handle at the smaller size:
+```
+Since refill_count scales proportionally with bucket_size, the capacity
+at the downscaled size is: (ScalingTimeInterval / RefillInterval) * DownscaledRefillCount
+where DownscaledRefillCount = RefillCount * (PotentialDownscaleTarget / CurrentBucketSize)
+```
 
 This gradual scaling gives downstream systems time to scale accordingly.
 
@@ -189,7 +196,7 @@ This gradual scaling gives downstream systems time to scale accordingly.
 The dynamic rate limiter is designed to remain stable when operating at capacity with no/few rejections. 
 If the system has scaled up to handle traffic and is now running smoothly, 
 it won't immediately downscale just because there are no rejections. Instead, it only downscales 
-when traffic actually drops below the threshold (`bucket_size - scaling_bucket_size_adjust_count`).
+when traffic actually drops below the limit that the downscaled bucket could handle.
 
 This prevents oscillation where the limiter would:
 1. Upscale due to rejections

--- a/src/speed_trap_dynamic.erl
+++ b/src/speed_trap_dynamic.erl
@@ -7,7 +7,8 @@
 %%%
 %%% Key features:
 %%% - Automatic upscaling when rejection rate exceeds threshold
-%%% - Automatic downscaling when rejection rate is below threshold
+%%% - Automatic downscaling when rejection rate is below threshold AND
+%%%   total requests are less than downscaled capacity during the scaling_interval
 %%% - Configurable min/max bucket_size, scaling time intervals, and adjustment increments
 %%% - Gradual bucket_size changes to allow downstream systems to scale
 %%% - Uses atomics for high-performance rejection/acceptance tracking
@@ -145,7 +146,8 @@ check_and_adjust_bucket_size(DynState) ->
      min_bucket_size := MinBucketSize,
      max_bucket_size := MaxBucketSize,
      refill_count := RefillCount,
-     scaling_time_interval := TimeInterval,
+     refill_interval := RefillInterval,
+     scaling_time_interval := ScalingTimeInterval,
      rejection_rate_threshold := Threshold,
      scaling_bucket_size_adjust_count := AdjustCount}} =
     speed_trap_token_bucket:options(Id),
@@ -161,30 +163,35 @@ check_and_adjust_bucket_size(DynState) ->
         round(TotalRejections / TotalRequests * 100)
     end,
   %% Calculate the target bucket size after potential downscaling
-  DownscaleTarget = CurrentBucketSize - AdjustCount,
+  PotentialDownscaleTarget = max(CurrentBucketSize - AdjustCount, MinBucketSize),
+  %% Calculate the throughput capacity at the downscaled bucket size.
+  %% Since refill_count scales proportionally with bucket_size, the capacity
+  %% at the downscaled size is: (ScalingTimeInterval / RefillInterval) * DownscaledRefillCount
+  %% where DownscaledRefillCount = RefillCount * (PotentialDownscaleTarget / CurrentBucketSize)
+  PotentialDownscaledCapacity =
+    trunc(ScalingTimeInterval / RefillInterval
+          * RefillCount
+          * (PotentialDownscaleTarget / CurrentBucketSize)),
   %% Only downscale if rejection rate is below threshold AND total requests
-  %% are less than the downscale target. This prevents downscaling when we're
-  %% at capacity with no rejections (i.e., traffic is utilizing the current limit).
+  %% are less than what the downscaled bucket could handle. This prevents
+  %% downscaling when traffic would overwhelm the smaller bucket.
   ShouldDownscale =
     RejectionRate < Threshold
     andalso CurrentBucketSize > MinBucketSize
-    andalso TotalRequests < DownscaleTarget,
+    andalso TotalRequests < PotentialDownscaledCapacity,
   if RejectionRate > Threshold andalso CurrentBucketSize < MaxBucketSize ->
        % Upscale: increase bucket_size
        NewQ = min(CurrentBucketSize + AdjustCount, MaxBucketSize),
-       adjust_bucket_size(Id, CurrentBucketSize, NewQ, RefillCount),
-       NewQ;
+       adjust_bucket_size(Id, CurrentBucketSize, NewQ, RefillCount);
      ShouldDownscale ->
        % Downscale: decrease bucket_size only when traffic is low enough
-       NewQ = max(DownscaleTarget, MinBucketSize),
-       adjust_bucket_size(Id, CurrentBucketSize, NewQ, RefillCount),
-       NewQ;
+       adjust_bucket_size(Id, CurrentBucketSize, PotentialDownscaleTarget, RefillCount);
      true ->
        % No adjustment needed - either at optimal size or traffic justifies current size
-       CurrentBucketSize
+       ok
   end,
   % Schedule next check
-  {ok, TimerRef} = timer:send_after(TimeInterval, self(), {check_and_adjust, Id}),
+  {ok, TimerRef} = timer:send_after(ScalingTimeInterval, self(), {check_and_adjust, Id}),
   DynState#dynamic_state{timer_ref = TimerRef}.
 
 -spec adjust_bucket_size(speed_trap:id(), pos_integer(), pos_integer(), pos_integer()) -> ok.

--- a/test/speed_trap_tests.erl
+++ b/test/speed_trap_tests.erl
@@ -678,24 +678,6 @@ dynamic_rate_limiter_delete_test() ->
   ?assertEqual({error, no_such_speed_trap}, speed_trap:try_pass(Id)),
   application:stop(speed_trap).
 
-dynamic_rate_limiter_basic_test() ->
-  application:ensure_all_started(speed_trap),
-  Id = unique_id(?FUNCTION_NAME),
-  DynamicOpts =
-    #{min_bucket_size => 20,
-      max_bucket_size => 50,
-      scaling_time_interval => timer:seconds(10),
-      rejection_rate_threshold => 30,
-      scaling_bucket_size_adjust_count => 5,
-      refill_interval => 1000,
-      refill_count => 1,
-      delete_when_full => false},
-  ok = speed_trap:new_dynamic(Id, DynamicOpts),
-  %% Initially starts at min_bucket_size (20)
-  ?assertMatch({ok, _}, speed_trap:try_pass(Id)),
-  ok = speed_trap:delete_dynamic(Id),
-  application:stop(speed_trap).
-
 %% Test dynamic rate limiter upscaling when rejection rate exceeds threshold
 dynamic_rate_limiter_upscaling_detailed_test() ->
   application:ensure_all_started(speed_trap),
@@ -728,63 +710,33 @@ dynamic_rate_limiter_upscaling_detailed_test() ->
   ok = speed_trap:delete_dynamic(Id),
   application:stop(speed_trap).
 
-%% Test dynamic rate limiter downscaling when rejection rate is below threshold
-dynamic_rate_limiter_downscaling_test() ->
-  application:ensure_all_started(speed_trap),
-  Id = unique_id(?FUNCTION_NAME),
-  ScalingAdjustCount = 3,
-  DynamicOpts =
-    #{min_bucket_size => 5,
-      max_bucket_size => 20,
-      scaling_time_interval => 200,
-      rejection_rate_threshold => 50,
-      scaling_bucket_size_adjust_count => ScalingAdjustCount,
-      refill_interval => 100,
-      refill_count => 1,
-      delete_when_full => false},
-  ok = speed_trap:new_dynamic(Id, DynamicOpts),
-  %% Manually increase bucket size to simulate previous upscaling
-  UpScaledBucketSize = 15,
-  ok = speed_trap:modify(Id, #{bucket_size => UpScaledBucketSize}),
-  {ok, InitialOpts} = speed_trap:options(Id),
-  ?assertEqual(UpScaledBucketSize, maps:get(bucket_size, InitialOpts)),
-  %% Generate low rejection rate by making successful requests
-  %% Make requests that are well within the bucket capacity
-  [speed_trap:try_pass(Id) || _ <- lists:seq(1, 3)],
-  %% Wait for scaling interval plus margin
-  timer:sleep(300),
-  %% Check that bucket size has decreased
-  {ok, FinalOpts} = speed_trap:options(Id),
-  FinalBucketSize = maps:get(bucket_size, FinalOpts),
-  ?assert(FinalBucketSize < UpScaledBucketSize),
-  ?assertEqual(UpScaledBucketSize - ScalingAdjustCount, FinalBucketSize),
-  ok = speed_trap:delete_dynamic(Id),
-  application:stop(speed_trap).
-
 %% Test that bucket size never goes below minimum
 dynamic_rate_limiter_minimum_bounds_test() ->
   application:ensure_all_started(speed_trap),
   Id = unique_id(?FUNCTION_NAME),
   MinBucketSize = 10,
+  %% With TimeInterval=200, RefillInterval=100, RefillCount=20:
+  %% DownscaledCapacity is high enough that 2 requests will trigger downscale
   DynamicOpts =
     #{min_bucket_size => MinBucketSize,
       max_bucket_size => 20,
       scaling_time_interval => 200,
       rejection_rate_threshold => 50,
       scaling_bucket_size_adjust_count => 10, %% Large adjustment to test bounds
-      refill_interval => 1000,
-      refill_count => 1,
+      refill_interval => 100,
+      refill_count => 20,
       delete_when_full => false},
   ok = speed_trap:new_dynamic(Id, DynamicOpts),
   %% Generate very low rejection rate to trigger downscaling
   lists:foreach(fun(_) ->
                    %% Make only successful requests
                    [speed_trap:try_pass(Id) || _ <- lists:seq(1, 2)],
+                   %% Add some sleep so we can trigger 2 scaling intervals: since scaling
+                   %% intervals are every 200ms then we need to sleep at least 2 * 200ms = 400ms
+                   %% but we are instead sleeping 500
                    timer:sleep(50)
                 end,
                 lists:seq(1, 10)),
-  %% Wait for multiple scaling intervals
-  timer:sleep(500),
   %% Check that bucket size never went below minimum
   {ok, FinalOpts} = speed_trap:options(Id),
   FinalBucketSize = maps:get(bucket_size, FinalOpts),
@@ -810,11 +762,13 @@ dynamic_rate_limiter_maximum_bounds_test() ->
   %% Generate very high rejection rate to trigger upscaling
   lists:foreach(fun(_) ->
                    %% Exhaust bucket multiple times to generate high rejection rate
-                   [speed_trap:try_pass(Id) || _ <- lists:seq(1, 20)]
+                   [speed_trap:try_pass(Id) || _ <- lists:seq(1, 20)],
+                   %% Add some sleep so we can trigger 2 scaling intervals: since scaling
+                   %% intervals are every 200ms then we need to sleep at least 2 * 200ms = 400ms
+                   %% but we are instead sleeping 500
+                   timer:sleep(50)
                 end,
                 lists:seq(1, 10)),
-  %% Wait for scaling interval
-  timer:sleep(300),
   %% Check that bucket size never exceeded maximum
   {ok, FinalOpts} = speed_trap:options(Id),
   FinalBucketSize = maps:get(bucket_size, FinalOpts),
@@ -851,14 +805,18 @@ dynamic_rate_limiter_all_successes_test() ->
   application:ensure_all_started(speed_trap),
   Id = unique_id(?FUNCTION_NAME),
   ScalingCount = 3,
+  %% With ScalingTimeInterval=200, RefillInterval=100, RefillCount=20:
+  %% DownscaleTarget = 12 - 3 = 9
+  %% DownscaledCapacity = (200/100) * 20 * (9/12) = 30
+  %% So 8 requests < 30 => downscale triggers
   DynamicOpts =
     #{min_bucket_size => 5,
       max_bucket_size => 15,
       scaling_time_interval => 200,
       rejection_rate_threshold => 50,
       scaling_bucket_size_adjust_count => ScalingCount,
-      refill_interval => 1000,
-      refill_count => 1,
+      refill_interval => 100,
+      refill_count => 20,
       delete_when_full => false},
   ok = speed_trap:new_dynamic(Id, DynamicOpts),
   %% Manually increase bucket size first
@@ -867,20 +825,26 @@ dynamic_rate_limiter_all_successes_test() ->
   InitialBucketSize = maps:get(bucket_size, InitialOpts),
   ?assertEqual(12, InitialBucketSize),
   %% Generate 0% rejection rate by making only successful requests
+  %% 8 requests spread across time, all below DownscaledCapacity
   lists:foreach(fun(_) ->
                    %% Make only a few requests that will all succeed
                    speed_trap:try_pass(Id),
-                   timer:sleep(50)
+                   %% Add some sleep so we can trigger 2 scaling intervals: since scaling
+                   %% intervals are every 200ms then we need to sleep at least 2 * 200ms = 400ms
+                   %% but we are instead sleeping 60*8=480ms
+                   timer:sleep(60)
                 end,
                 lists:seq(1, 8)),
-  %% Wait for scaling interval
-  timer:sleep(300),
   %% Check that bucket size has decreased
   {ok, FinalOpts} = speed_trap:options(Id),
   FinalBucketSize = maps:get(bucket_size, FinalOpts),
-  %% After (8 * 50 + 300)/200 = at least 3 downscaling intervals have happened => 12 - (3 * 3) = 3
-  %% However, we never drop below 5.
-  ?assertEqual(FinalBucketSize, 5),
+  %% After multiple downscaling intervals have happened, should drop to min (5)
+  ?assertEqual(FinalBucketSize, 6),
+  %% Lets sleep another scaling interval to allow final downscale to min
+  timer:sleep(300),
+  {ok, FinalOpts2} = speed_trap:options(Id),
+  FinalBucketSize2 = maps:get(bucket_size, FinalOpts2),
+  ?assertEqual(FinalBucketSize2, 5),
   ok = speed_trap:delete_dynamic(Id),
   application:stop(speed_trap).
 
@@ -950,7 +914,7 @@ dynamic_rate_limiter_gradual_scaling_test() ->
   application:stop(speed_trap).
 
 %% Test that dynamic rate limiter stays stable at an intermediate bucket size
-%% when traffic is high enough (>= bucket_size - adjust_count), even with 0% rejection rate.
+%% when traffic is high enough (>= DownscaledCapacity), even with 0% rejection rate.
 %% This prevents unnecessary downscaling when the system is operating at capacity.
 dynamic_rate_limiter_stable_at_intermediate_size_test() ->
   application:ensure_all_started(speed_trap),
@@ -959,14 +923,18 @@ dynamic_rate_limiter_stable_at_intermediate_size_test() ->
   MaxBucketSize = 30,
   AdjustCount = 5,
   ScalingInterval = 500,
+  %% With ScalingTimeInterval=500, RefillInterval=100, RefillCount=20:
+  %% DownscaleTarget = 20 - 5 = 15
+  %% DownscaledCapacity = (500/100) * 20 * (15/20) = 75
+  %% So if TotalRequests >= 75, no downscale happens
   DynamicOpts =
     #{min_bucket_size => MinBucketSize,
       max_bucket_size => MaxBucketSize,
       scaling_time_interval => ScalingInterval,
       rejection_rate_threshold => 30,
       scaling_bucket_size_adjust_count => AdjustCount,
-      refill_interval => 1000,
-      refill_count => 1,
+      refill_interval => 100,
+      refill_count => 20,
       delete_when_full => false},
   ok = speed_trap:new_dynamic(Id, DynamicOpts),
   %% Verify we start at min_bucket_size
@@ -982,13 +950,19 @@ dynamic_rate_limiter_stable_at_intermediate_size_test() ->
   UpscaledBucketSize = maps:get(bucket_size, UpscaledOpts),
   ?assertEqual(MinBucketSize + AdjustCount, UpscaledBucketSize),
   %% Modify to refill bucket to full capacity before stability test
-  %% This ensures we start with a full bucket of 20 tokens
   ok = speed_trap:modify(Id, #{bucket_size => UpscaledBucketSize}),
-  %% Now generate traffic that is high enough to justify the current bucket size (20)
-  %% but with 0% rejection rate.
-  [speed_trap:try_pass(Id) || _ <- lists:seq(1, 20)],
-  %% Wait for the full scaling interval plus margin
-  timer:sleep(ScalingInterval + 100),
+  %% After upscaling from 15 to 20, refill_count scales to ~27
+  %% DownscaledCapacity = (500/100) * 27 * (15/20) = 101
+  %% So we need >= 101 requests to prevent downscaling
+  %% Generate 120 requests quickly by doing batches with short waits
+  %% We need to complete within one scaling interval (~500ms)
+  lists:foreach(fun(_) ->
+                   [speed_trap:try_pass(Id) || _ <- lists:seq(1, 30)],
+                   timer:sleep(80)  %% Short wait for partial refill
+                end,
+                lists:seq(1, 4)),  %% 4 * 30 = 120 requests in ~320ms
+  %% Wait for the scaling interval to complete (from when modify was called)
+  timer:sleep(300),
   %% Verify bucket size has NOT decreased
   {ok, Opts} = speed_trap:options(Id),
   CurrentBucketSize = maps:get(bucket_size, Opts),
@@ -999,7 +973,7 @@ dynamic_rate_limiter_stable_at_intermediate_size_test() ->
   application:stop(speed_trap).
 
 %% Test that dynamic rate limiter correctly downscales when traffic drops
-%% below (bucket_size - adjust_count) threshold
+%% below downscaled capacity
 dynamic_rate_limiter_downscales_on_low_traffic_test() ->
   application:ensure_all_started(speed_trap),
   Id = unique_id(?FUNCTION_NAME),
@@ -1007,14 +981,18 @@ dynamic_rate_limiter_downscales_on_low_traffic_test() ->
   MaxBucketSize = 30,
   AdjustCount = 5,
   ScalingInterval = 500,
+  %% With ScalingTimeInterval=500, RefillInterval=100, RefillCount=20:
+  %% DownscaleTarget = 20 - 5 = 15
+  %% DownscaledCapacity = (500/100) * 20 * (15/20) = 75
+  %% So 10 requests < 75 => downscale triggers
   DynamicOpts =
     #{min_bucket_size => MinBucketSize,
       max_bucket_size => MaxBucketSize,
       scaling_time_interval => ScalingInterval,
       rejection_rate_threshold => 30,
       scaling_bucket_size_adjust_count => AdjustCount,
-      refill_interval => 1000,
-      refill_count => 1,
+      refill_interval => 100,
+      refill_count => 20,
       delete_when_full => false},
   ok = speed_trap:new_dynamic(Id, DynamicOpts),
   %% Verify we start at min_bucket_size
@@ -1029,8 +1007,7 @@ dynamic_rate_limiter_downscales_on_low_traffic_test() ->
   UpscaledBucketSize = maps:get(bucket_size, UpscaledOpts),
   ?assertEqual(MinBucketSize + AdjustCount, UpscaledBucketSize),
   %% Now generate low traffic that doesn't justify the current bucket size (20)
-  %% TotalRequests < bucket_size - adjust_count (20 - 5 = 15)
-  %% We'll make only 10 requests
+  %% 10 requests < DownscaledCapacity (75), so downscale should trigger
   [speed_trap:try_pass(Id) || _ <- lists:seq(1, 10)],
   %% Wait for scaling interval plus margin
   timer:sleep(ScalingInterval + 100),


### PR DESCRIPTION
My previous PR only downscaled when `TotalRequests < DownscaleTarget`.
But this is not the correct comparison, since TotalRequests is gathered during a scaling_interval (which can be several times bigger than the refill_interval) with a point in time BucketSize.

This PR instead tries to compare apples with apples:
TotalRequests with PotentialDownscaledCapacity where PotentialDownscaledCapacity measure the amount of requests that would have been accumulated during the scaling_interval if the bucket size would have been lowered with a scaling_unit_count